### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,7 @@
           </ul>
         </div>
         <div class="copyright">
-          © Copyright 2016 Salesforce.com, inc. All rights reserved. Various trademarks held by their respective owners. Salesforce.com, inc. The Landmark at One Market, Suite 300, San Francisco, CA 94105, United States
+          © Copyright 2016 Salesforce.com, inc. <a href="http://www.salesforce.com/company/legal/intellectual.jsp">All rights reserved</a>. Various trademarks held by their respective owners. Salesforce.com, inc. The Landmark at One Market, Suite 300, San Francisco, CA 94105, United States
         </div>
       </footer>
     </div>


### PR DESCRIPTION
Never seen "foo, inc." though salesforce.com does seem to use it that way. Then again they use "salesforce.com, Inc"[sic] at one point so maybe they're not a good source of truth. Verified against Alphabet Inc. and VMware Inc.

Add IP notice similar to salesforce.com